### PR TITLE
Handle IFC schema fallback

### DIFF
--- a/public/pyodideWorker.js
+++ b/public/pyodideWorker.js
@@ -506,7 +506,7 @@ from ifcopenshell.util.schema import get_fallback_schema
 with open("model.ifc", "r", encoding="utf-8", errors="ignore") as fh:
     ifc_data = fh.read()
 
-match = re.search(r"FILE_SCHEMA\s*\(\s*\(?['\"]([^'\"]+)['\"]\)?", ifc_data, re.IGNORECASE)
+match = re.search(r"FILE_SCHEMA\\s*\\(\\s*\\(?['\\"]([^'\\"]+)['\\"]\\)?", ifc_data, re.IGNORECASE)
 schema_id = match.group(1) if match else None
 
 try:
@@ -515,9 +515,17 @@ except Exception:
     if schema_id:
         try:
             fallback = get_fallback_schema(schema_id)
+        except Exception:
+            fallback = "IFC4"
+
+        try:
             model = ifcopenshell.file.from_string(ifc_data.replace(schema_id, fallback))
         except Exception:
-            raise
+            if fallback != "IFC4":
+                # last resort fallback to IFC4
+                model = ifcopenshell.file.from_string(ifc_data.replace(schema_id, "IFC4"))
+            else:
+                raise
     else:
         raise
 

--- a/public/python/model_checker.py
+++ b/public/python/model_checker.py
@@ -170,8 +170,19 @@ def test_ifc(ifc_path: str, ids_path: str, report_path: str = "report.html", lan
             ifc_model = ifcopenshell.open(ifc_path)
         except Exception:
             if schema_id:
-                fallback = get_fallback_schema(schema_id)
-                ifc_model = ifcopenshell.file.from_string(ifc_data.replace(schema_id, fallback))
+                try:
+                    fallback = get_fallback_schema(schema_id)
+                except Exception:
+                    fallback = "IFC4"
+
+                try:
+                    ifc_model = ifcopenshell.file.from_string(ifc_data.replace(schema_id, fallback))
+                except Exception:
+                    if fallback != "IFC4":
+                        # last resort fallback to IFC4
+                        ifc_model = ifcopenshell.file.from_string(ifc_data.replace(schema_id, "IFC4"))
+                    else:
+                        raise
             else:
                 raise
         

--- a/src/__test__/snapshotSerializer.ts
+++ b/src/__test__/snapshotSerializer.ts
@@ -1,0 +1,8 @@
+export default {
+  test() {
+    return false
+  },
+  print(val: unknown) {
+    return String(val)
+  },
+}

--- a/src/__tests__/normalizeSchema.test.ts
+++ b/src/__tests__/normalizeSchema.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'child_process'
+
+describe('normalize_schema', () => {
+  const run = (schema: string) => {
+    const py = [
+      'import sys, os',
+      "sys.path.append('public')",
+      "from python.model_checker import normalize_schema",
+      `print(normalize_schema('${schema}'))`
+    ].join('\n')
+    return spawnSync('python3', ['-c', py])
+  }
+
+  it('handles IFC4X3_ADD2', () => {
+    const r = run('IFC4X3_ADD2')
+    expect(r.status).toBe(0)
+    expect(r.stdout.toString().trim()).toBe('IFC4X3')
+  })
+
+  it('defaults unknown to IFC4', () => {
+    const r = run('UNKNOWN')
+    expect(r.status).toBe(0)
+    expect(r.stdout.toString().trim()).toBe('IFC4')
+  })
+})

--- a/src/__tests__/schemaFallback.test.ts
+++ b/src/__tests__/schemaFallback.test.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-useless-escape */
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'child_process'
+
+describe('schema fallback', () => {
+  it('maps IFC4X3_RC1 to IFC4X3', () => {
+    const py = "from ifcopenshell.util.schema import get_fallback_schema;print(get_fallback_schema('IFC4X3_RC1'))"
+    const result = spawnSync('python3', ['-c', py])
+    expect(result.status).toBe(0)
+    expect(result.stdout.toString().trim()).toBe('IFC4X3')
+  })
+})


### PR DESCRIPTION
## Summary
- fallback to supported schema when IFC version isn't recognized in the web worker
- apply the same fallback logic in the CLI script
- add snapshot serializer stub for Vitest
- test `get_fallback_schema` for IFC4X3_RC1

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684003e972648320bda74e017b0a0594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of IFC model files with unsupported or problematic schemas by introducing a fallback mechanism, increasing compatibility and robustness when opening IFC files.

- **Tests**
  - Added new tests to verify the fallback schema logic for IFC files.
  - Updated snapshot serializer logic for improved test output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->