### PR TITLE
Improve upload robustness

### DIFF
--- a/src/components/UploadCard/UploadCard.tsx
+++ b/src/components/UploadCard/UploadCard.tsx
@@ -34,6 +34,7 @@ export const UploadCard = () => {
     bcf: false,
   })
   const resultsRef = useRef<HTMLDivElement>(null)
+  const lastParams = useRef<{ ifc: File[]; ids: File | null; idsValidation: boolean } | null>(null)
 
   const addLog = (message: string) => {
     setProcessingLogs((prev) => [...prev, message])
@@ -103,9 +104,21 @@ export const UploadCard = () => {
     }
   }
 
+  const handleRetry = async () => {
+    if (lastParams.current) {
+      await processFiles(lastParams.current.ifc, lastParams.current.ids, lastParams.current.idsValidation)
+    }
+  }
+
+  const handleSkip = () => {
+    setUploadError(null)
+  }
+
   const handleClick = async () => {
     setUploadError(null)
     setProcessedResults([])
+
+    lastParams.current = { ifc: ifcFiles, ids: idsFile, idsValidation: isIdsValidation }
 
     if (isIdsValidation && idsFile) {
       if (!ifcFiles.length) return
@@ -168,7 +181,13 @@ export const UploadCard = () => {
             />
           </Box>
 
-          <ErrorDisplay errors={errors} uploadProgress={uploadProgress} uploadError={uploadError} />
+          <ErrorDisplay
+            errors={errors}
+            uploadProgress={uploadProgress}
+            uploadError={uploadError}
+            onRetry={uploadError ? handleRetry : undefined}
+            onSkip={uploadError ? handleSkip : undefined}
+          />
 
           <ProcessingConsole isProcessing={isProcessing} logs={processingLogs} />
 

--- a/src/components/UploadCard/components/ErrorDisplay.tsx
+++ b/src/components/UploadCard/components/ErrorDisplay.tsx
@@ -1,4 +1,4 @@
-import { Alert, Progress, Text, Box } from '@mantine/core'
+import { Alert, Progress, Text, Box, Group, Button } from '@mantine/core'
 import { useTranslation } from 'react-i18next'
 import { FileError } from '../hooks/useFileProcessor'
 
@@ -6,9 +6,11 @@ interface ErrorDisplayProps {
   errors: FileError[] | null
   uploadProgress: number
   uploadError: string | null
+  onRetry?: () => void
+  onSkip?: () => void
 }
 
-export const ErrorDisplay = ({ errors, uploadProgress, uploadError }: ErrorDisplayProps) => {
+export const ErrorDisplay = ({ errors, uploadProgress, uploadError, onRetry, onSkip }: ErrorDisplayProps) => {
   const { t } = useTranslation()
 
   return (
@@ -32,6 +34,20 @@ export const ErrorDisplay = ({ errors, uploadProgress, uploadError }: ErrorDispl
             <Box mt='sm'>
               <Text fw={700}>{t('console.loading.reloading', 'Page will reload in 3 seconds...')}</Text>
             </Box>
+          )}
+          {(onRetry || onSkip) && (
+            <Group mt='sm' gap='xs'>
+              {onRetry && (
+                <Button size='xs' color='yellow' variant='light' onClick={onRetry}>
+                  {t('retry', 'Retry')}
+                </Button>
+              )}
+              {onSkip && (
+                <Button size='xs' color='gray' variant='light' onClick={onSkip}>
+                  {t('skip', 'Continue')}
+                </Button>
+              )}
+            </Group>
           )}
         </Alert>
       )}


### PR DESCRIPTION
## Summary
- provide retry/skip options when validation fails
- expose callbacks in `ErrorDisplay`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: No test files found)*
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_6880b3677ffc8320aa3011ceafb3580a